### PR TITLE
Stop/Kill 

### DIFF
--- a/Stop-Kill.c
+++ b/Stop-Kill.c
@@ -1,0 +1,12 @@
+// Support kill command: "kill PID"
+if (argv[0] && strcmp(argv[0], "kill") == 0 && argv[1]) {
+  int kpid = atoi(argv[1]);
+  if (remove_pid(bg_pids, &bg_count, kpid)) {
+    if (kill(kpid) < 0)
+      printf("init: failed to kill pid %d\n", kpid);
+    else
+      printf("init: killed pid %d\n", kpid);
+  } else {
+    printf("init: pid %d not found in background jobs\n", kpid);
+  }
+}


### PR DESCRIPTION
Checks if the command is kill <pid>.
Converts the given PID string to an integer.
Uses remove_pid() to remove the PID from the background process tracking list (bg_pids). If successful, attempts to kill() the process.
Logs whether the kill succeeded or failed.