### PR TITLE
Auto-Restart Failed Jobs

### DIFF
--- a/Auto-Restart failed Jobs.c
+++ b/Auto-Restart failed Jobs.c
@@ -1,0 +1,19 @@
+void run_with_restart(char argv) {
+    int pid;
+    while (1) {
+        if ((pid = fork()) == 0) {
+            exec(argv[0], argv);  Run the service
+            exit(1);  In case exec fails
+        } else {
+            wait(0);  Wait for the child to exit, then restart
+        }
+    }
+}
+// Background service with restart
+if (bg) {
+    if ((pid = fork()) == 0) {
+        run_with_restart(argv); // Run in restart loop
+    } else {
+        bg_pids[bg_count++] = pid; // Track PID
+    }
+}


### PR DESCRIPTION
**_Auto-Restart Failed Jobs_**

Description:

      - Background services are run using run_with_restart().
      
      - If the process exits, it is automatically restarted in an infinite loop.
       
      - Ensures persistent background services, simulating daemon behavior.